### PR TITLE
Add link to libsodium

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 This document describes the bytes over the wire to speak the cable protocol.
 
-You will need libsodium bindings or their equivalents for:
+You will need [libsodium](https://doc.libsodium.org/) bindings or their equivalents for:
 
 * `crypto_generichash()` - to hash messages with blake2
 * `crypto_sign_keypair()` - to generate public and secret ed25519 keys


### PR DESCRIPTION
Allows users to learn about libsodium without needing to search for it themselves.