### PR TITLE
Fix `cancel_id` type for `Cancel Request`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -719,7 +719,7 @@ This request can be used to terminated previously sent, long-lived requests.
 
 field        | type                | desc
 -------------|---------------------|-------------------------------------
-`cancel_id`  | `varint`            | the `req_id` of the request to be cancelled
+`cancel_id`  | `u8[4]`             | the `req_id` of the request to be cancelled
 
 Receiving this request indicates that any further responses sent back with a
 `req_id` matching the given `cancel_id` will be ignored and discarded.


### PR DESCRIPTION
I noticed a small mistake in the type definition for `cancel_id`.

Was `varint`, should be `u8[4]` (matches `req_id`).