### PR TITLE
Specify end of stream behaviour

### DIFF
--- a/handshake.md
+++ b/handshake.md
@@ -498,11 +498,17 @@ Reading a Cable Wire Protocol message MUST follow these steps:
    message.
 
 ### 5.5 End of stream
-After a complete Cable Wire Protocol message is sent, regardless of whether
-it consists of one or several fragments, the sender MUST write a message of
-`length=0`. This final message serves as an end of stream marker for the
-receiving peer and enables the peer to differentiate between an intentionally
-terminated stream and a dropped connection.
+When a host has decided to terminate the exchange of messages, they MUST send
+a message of length zero to indicate this intention, and MUST NOT send any
+further messages. The zero-length message is known as an end-of-stream marker.
+
+The host receiving an end-of-stream marker SHOULD respond with an
+end-of-stream marker of its own to indicate it has also finished writing. An
+implementation SHOULD have a time-out of some kind in case the other side does
+not transmit an end-of-stream marker or the marker is truncated by an attacker.
+
+When a host has both sent and received a zero-length message, it is then safe
+for the underlying transport to execute its own disconnect logic, if any.
 
 ## 6. Security considerations
 ### 6.1 Out-of-scope attacks

--- a/handshake.md
+++ b/handshake.md
@@ -461,17 +461,12 @@ these steps:
 
 3. `WriteMsg(plaintext)`
 
-4. `WriteBytes(0)`
-
 If, for example, a `plaintext` of length 90200 were to be encoded & written,
 the first 65519 bytes would first be encrypted and written, followed by the
 remaining 24681 bytes being encrypted and written. Since each ciphertext has an
 extra 16 bytes added of authentication data, and there are two segments
 written, the total written length would be `65519 + 24681 + 16 * 2 = 90232`
 bytes.
-
-The fourth step is described in the [End of stream](#55-end-of-stream)
-subsection.
 
 ### 5.4 Message decoding
 This subsection defines pseudocode function `plaintext = ReadMsg(len)` that

--- a/handshake.md
+++ b/handshake.md
@@ -372,7 +372,7 @@ Noise for encryption, and then prefixed with an encrypted length indicator.
 Incoming Cable Wire Protocol messages will also be length-prefixed, and the
 message bodies will be encrypted as *ciphertext*s, and must be run through
 Noise for decryption. There are additional steps to handle message
-fragmentation and end of stream markers, described in the next subsection.
+fragmentation and the end of the stream, described in the next subsection.
 
 The Noise function `Split()`, run at the end of the Noise Handshake, returns a
 pair of `CipherState` objects `(c1, c2)` to be used as follows:

--- a/handshake.md
+++ b/handshake.md
@@ -1,8 +1,8 @@
 # Cable Handshake
 
-Version: 1.0-draft6
+Version: 1.0-draft7
 
-Published: January 2024
+Published: February 2024
 
 Author: Kira Oakley
 


### PR DESCRIPTION
Relates to https://github.com/cabal-club/cable/issues/17

This is a short-and-sweet revision of the handshake specification to document the end of stream requirement when writing messages.

@hackergrrl, please feel free to edit as desired.